### PR TITLE
fix: add plugin metadata to release-please config (#5)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
   "extra-files": [
-    "README.md"
+    "README.md",
+    "internal/cnpgi/metadata/constants.go"
   ],
   "prerelease": false,
   "packages": {


### PR DESCRIPTION
While the file already contains the correct comment, it's not included in the list checked by release-please.