### PR TITLE
fix: patch roles properly (#7)

### DIFF
--- a/internal/cnpgi/operator/reconciler.go
+++ b/internal/cnpgi/operator/reconciler.go
@@ -184,8 +184,10 @@ func (r ReconcilerImplementation) ensureRole(
 		"namespace", newRole.Namespace,
 		"rules", newRole.Rules,
 	)
-	// TODO: Something is wrong here, we also should check for ownership.
-	return r.Client.Patch(ctx, newRole, client.MergeFrom(&role))
+
+	patch := client.MergeFrom(role.DeepCopy())
+	role.Rules = newRole.Rules
+	return r.Client.Patch(ctx, &role, patch)
 }
 
 func (r ReconcilerImplementation) ensureRoleBinding(


### PR DESCRIPTION
Patch call expects a modified existing resource as the first argument, not a set of new values.

Now this logic should match official docs:
https://sdk.operatorframework.io/docs/building-operators/golang/references/client/#patch

Closes #7.