### PR TITLE
chore(dagger): bump to 0.18.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dagger
         env:
           # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.16.1
+          DAGGER_VERSION: 0.18.5
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
       - name: Run CI task

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Dagger
         env:
           # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.16.1
+          DAGGER_VERSION: 0.18.5
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
       - name: Create image and manifest

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Dagger
         env:
           # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-          DAGGER_VERSION: 0.16.1
+          DAGGER_VERSION: 0.18.5
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
       - name: Create image and manifest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,7 +147,7 @@ tasks:
       - start-build-network
     vars:
       # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
-      DAGGER_VERSION: 0.16.1
+      DAGGER_VERSION: 0.18.5
       DAGGER_ENGINE_IMAGE: registry.dagger.io/engine:v{{ .DAGGER_VERSION }}
     cmds:
       - >


### PR DESCRIPTION
Note that 0.18.6 fixes a param validation bug that allows golangci-lint to work. Until either golangci-lint changes its params or dagger provides a way to specify conflicting params, newer versions cannot be used.

Check those issues for details:
https://github.com/sagikazarmark/daggerverse/issues/64 https://github.com/dagger/dagger/issues/7032