### PR TITLE
ci: relax golangci-lint rules about package names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,10 @@ linters:
           - revive
         text: should not use dot imports
         source: ginkgo|gomega
+      # Allow packages like helpers or utils.
+      - linters:
+          - revive
+        text: avoid meaningless package names
       # Exclude some linters from running on tests files.
       - linters:
           - goconst


### PR DESCRIPTION
This rule has been introduced in an update and current code base doesn't conform to it. Refactoring utility functions to different packages doesn't make sense at this moment.