### PR TITLE
Fix conflicting leaderElectionId between backup plugins

### DIFF
--- a/internal/cnpgi/operator/manager.go
+++ b/internal/cnpgi/operator/manager.go
@@ -106,7 +106,7 @@ func Start(ctx context.Context) error {
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: viper.GetString("health-probe-bind-address"),
 		LeaderElection:         viper.GetBool("leader-elect"),
-		LeaderElectionID:       "822e3f5c.cnpg.io",
+		LeaderElectionID:       "5e3f9a6c.cnpg.io",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
Both cnpg-plugin-pgbackrest and plugin-barman-cloud currently use the same leaderElectionId, causing leader election conflicts when deployed simultaneously in the same Kubernetes cluster. This prevents organizations from using multiple backup strategies (e.g., different plugins for different PostgreSQL clusters, migration scenarios, or multi-tenant environments). Each plugin should use a unique leader election ID to enable peaceful coexistence and allow users to deploy multiple CNPG-I backup plugins without leadership conflicts.