### PR TITLE
feat: support multiple AWS key types

### DIFF
--- a/config/crd/bases/pgbackrest.cnpg.opera.com_archives.yaml
+++ b/config/crd/bases/pgbackrest.cnpg.opera.com_archives.yaml
@@ -254,6 +254,11 @@ spec:
                               - key
                               - name
                               type: object
+                            keyType:
+                              default: shared
+                              description: KeyType specifies the type of key used
+                                for S3 credentials
+                              type: string
                             region:
                               description: |-
                                 The reference to the secret containing the region name.

--- a/internal/pgbackrest/api/config.go
+++ b/internal/pgbackrest/api/config.go
@@ -59,6 +59,18 @@ const (
 	CompressionTypeZstd = CompressionType("zst")
 )
 
+// KeyType is the type of key used for S3 credentials
+type KeyType string
+
+const (
+	// KeyTypeShared Shared keys
+	KeyTypeShared = KeyType("shared")
+	// KeyTypeAuto Automatically retrieve temporary credentials
+	KeyTypeAuto = KeyType("auto")
+	// KeyTypeWebID Automatically retrieve web identity credentials
+	KeyTypeWebID = KeyType("web-id")
+)
+
 // S3Credentials is the type for the credentials to be used to upload
 // files to S3. It can be provided in two alternative ways:
 //
@@ -66,6 +78,11 @@ const (
 //
 // - inheriting the role from the pod environment by setting inheritFromIAMRole to true
 type S3Credentials struct {
+	// KeyType specifies the type of key used for S3 credentials
+	// +optional
+	// +kubebuilder:default:=shared
+	KeyType KeyType `json:"keyType,omitempty"`
+
 	// The reference to the access key ID
 	// +optional
 	AccessKeyIDReference *machineryapi.SecretKeySelector `json:"accessKeyId,omitempty"`

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -253,6 +253,11 @@ spec:
                               - key
                               - name
                               type: object
+                            keyType:
+                              default: shared
+                              description: KeyType specifies the type of key used
+                                for S3 credentials
+                              type: string
                             region:
                               description: |-
                                 The reference to the secret containing the region name.


### PR DESCRIPTION
This PR adds a new `keyType` field to S3Credentials to allow users to backup to AWS compatible environments without static AWS credentials. This will allow AWS IRSA and Pod Identity Webhook methods in EKS to authenticate with S3. This defaults to `shared` which allows backwards compatibility with the current access key method via secrets.

Closes #38 