### PR TITLE
fix: missing permissions when OwnerReferencesPermissionEnforcement admission controller is enabled

### DIFF
--- a/internal/controller/archive_controller.go
+++ b/internal/controller/archive_controller.go
@@ -39,6 +39,7 @@ type ArchiveReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;patch;update;get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;list;get;watch;delete
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=backups,verbs=get;list;watch
+// +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=pgbackrest.cnpg.opera.com,resources=archives,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=pgbackrest.cnpg.opera.com,resources=archives/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=pgbackrest.cnpg.opera.com,resources=archives/finalizers,verbs=update


### PR DESCRIPTION
Hi,

This is the same issue as https://github.com/cloudnative-pg/plugin-barman-cloud/issues/425
So I think the fix should be exactly the same.

I encountered the problem on an OpenShift environment.

Regards,
Clément