### PR TITLE
Fixing PgbackrestRetention.History processing

### DIFF
--- a/internal/pgbackrest/api/config_test.go
+++ b/internal/pgbackrest/api/config_test.go
@@ -158,3 +158,21 @@ var _ = Describe("Pgbackrest credentials", func() {
 		}.ArePopulated()).To(BeTrue())
 	})
 })
+
+var _ = Describe("Pgbackrest retention", func() {
+	var history int32 = 9
+
+	It("can check when policy is partially populated", func() {
+		policy1 := PgbackrestRetention{
+			Archive: 7,
+		}
+		policy2 := PgbackrestRetention{
+			History: &history,
+		}
+
+		Expect(policy1.History == nil).To(BeTrue())
+
+		Expect(policy2.History).To(Not(BeNil()))
+		Expect(*policy2.History).To(Equal(history))
+	})
+})

--- a/internal/pgbackrest/command/commandbuilder.go
+++ b/internal/pgbackrest/command/commandbuilder.go
@@ -20,6 +20,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	pgbackrestApi "github.com/operasoftware/cnpg-plugin-pgbackrest/internal/pgbackrest/api"
 	"github.com/operasoftware/cnpg-plugin-pgbackrest/internal/pgbackrest/utils"
@@ -140,7 +141,10 @@ func appendRetentionOptions(
 		options = append(
 			options,
 			utils.FormatRepoFlag(repoIndex, "retention-history"),
-			string(*retention.History))
+
+			// Simple string(*retention.History)) won't work below
+			// Keep in mind it's a pointer. Explicit cast and format calls are necessary
+			strconv.FormatInt(int64(*retention.History), 10))
 	}
 
 	return options, nil

--- a/internal/pgbackrest/command/commandbuilder_test.go
+++ b/internal/pgbackrest/command/commandbuilder_test.go
@@ -63,3 +63,41 @@ var _ = Describe("pgbackrestWalRestoreOptions", func() {
 				))
 	})
 })
+
+var _ = Describe("PgbackrestRetention", func() {
+	var config *pgbackrestApi.PgbackrestConfiguration
+	var history int32 = 8
+	retention := pgbackrestApi.PgbackrestRetention{
+		Archive:     5,
+		ArchiveType: "full",
+		Full:        6,
+		FullType:    "count",
+		Diff:        7,
+		History:     &history,
+	}
+	BeforeEach(func() {
+		config = &pgbackrestApi.PgbackrestConfiguration{
+			Repositories: []pgbackrestApi.PgbackrestRepository{
+				{
+					Retention: &retention,
+				},
+			},
+		}
+	})
+
+	It("should generate correct argument list for retention policy", func(ctx SpecContext) {
+		var empty []string
+		options, err := AppendRetentionOptionsFromConfiguration(ctx, empty, config)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Join(options, " ")).
+			To(
+				And(
+					ContainSubstring("--repo1-retention-archive-type full"),
+					ContainSubstring("--repo1-retention-full-type count"),
+					ContainSubstring("--repo1-retention-archive 5"),
+					ContainSubstring("--repo1-retention-full 6"),
+					ContainSubstring("--repo1-retention-diff 7"),
+					ContainSubstring("--repo1-retention-history 8"),
+				))
+	})
+})


### PR DESCRIPTION
Hi @Agalin ,

I believe this Pull Request fixes Issue #35 . The actual issue was in a way of processing `.retention.History` in `internal/pgbackrest/command/commandbuilder.go:143`. On top of this line I've also added a few tests to cover this area.

Please accept at your convenience.

Best regards,
Boris