### PR TITLE
fix: improve reliability of object cache management

### DIFF
--- a/internal/cnpgi/instance/internal/client/client_test.go
+++ b/internal/cnpgi/instance/internal/client/client_test.go
@@ -67,6 +67,7 @@ var _ = Describe("ExtendedClient Get", func() {
 			{
 				entry:         secretNotInClient,
 				fetchUnixTime: time.Now().Unix(),
+				ttl:           time.Duration(DefaultTTLSeconds) * time.Second,
 			},
 		}
 
@@ -80,6 +81,7 @@ var _ = Describe("ExtendedClient Get", func() {
 			{
 				entry:         secretInClient.DeepCopy(),
 				fetchUnixTime: time.Now().Add(-2 * time.Minute).Unix(),
+				ttl:           time.Duration(DefaultTTLSeconds) * time.Second,
 			},
 		}
 
@@ -90,6 +92,101 @@ var _ = Describe("ExtendedClient Get", func() {
 	It("fetches secret from base client if not in cache", func(ctx SpecContext) {
 		err := extendedClient.Get(ctx, client.ObjectKeyFromObject(secretInClient), secretInClient)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("caches Archive objects", func(ctx SpecContext) {
+		archiveResult := &v1.Archive{}
+		err := extendedClient.Get(ctx, client.ObjectKeyFromObject(archive), archiveResult)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(extendedClient.cachedObjects).To(HaveLen(1))
+		Expect(extendedClient.cachedObjects[0].entry.GetName()).To(Equal("test-object-store"))
+	})
+
+	It("distinguishes objects with same key but different types", func(ctx SpecContext) {
+		// Add a Secret with the same name as the archive to the cache
+		secretSameName := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-object-store",
+			},
+		}
+		extendedClient.cachedObjects = []cachedEntry{
+			{
+				entry:         secretSameName,
+				fetchUnixTime: time.Now().Unix(),
+				ttl:           time.Duration(DefaultTTLSeconds) * time.Second,
+			},
+		}
+
+		// Get the Archive with the same name - should come from base client, not from cached Secret
+		archiveResult := &v1.Archive{}
+		err := extendedClient.Get(ctx, client.ObjectKeyFromObject(archive), archiveResult)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(archiveResult.Name).To(Equal("test-object-store"))
+		// Should now have 2 cached entries: the Secret and the newly fetched Archive
+		Expect(extendedClient.cachedObjects).To(HaveLen(2))
+	})
+
+	It("removeObject removes matching type", func(ctx SpecContext) {
+		secretToRemove := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-secret",
+			},
+		}
+		extendedClient.cachedObjects = []cachedEntry{
+			{
+				entry:         secretToRemove,
+				fetchUnixTime: time.Now().Unix(),
+				ttl:           time.Duration(DefaultTTLSeconds) * time.Second,
+			},
+		}
+
+		err := extendedClient.Update(ctx, secretToRemove)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(extendedClient.cachedObjects).To(BeEmpty())
+	})
+
+	It("removeObject removes only matching type when keys are shared", func() {
+		secretSharedKey := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "shared-key",
+			},
+		}
+		archiveSharedKey := &v1.Archive{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "shared-key",
+			},
+		}
+
+		extendedClient.cachedObjects = []cachedEntry{
+			{
+				entry:         secretSharedKey,
+				fetchUnixTime: time.Now().Unix(),
+				ttl:           time.Duration(DefaultTTLSeconds) * time.Second,
+			},
+			{
+				entry:         archiveSharedKey,
+				fetchUnixTime: time.Now().Unix(),
+				ttl:           time.Duration(DefaultTTLSeconds) * time.Second,
+			},
+		}
+
+		extendedClient.removeObject(secretSharedKey)
+
+		Expect(extendedClient.cachedObjects).To(HaveLen(1))
+		_, isArchive := extendedClient.cachedObjects[0].entry.(*v1.Archive)
+		Expect(isArchive).To(BeTrue())
+		Expect(extendedClient.cachedObjects[0].entry.GetName()).To(Equal("shared-key"))
+	})
+
+	It("initializes TTL on cached entries", func(ctx SpecContext) {
+		err := extendedClient.Get(ctx, client.ObjectKeyFromObject(secretInClient), secretInClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(extendedClient.cachedObjects).To(HaveLen(1))
+		Expect(extendedClient.cachedObjects[0].ttl).To(Equal(time.Duration(DefaultTTLSeconds) * time.Second))
 	})
 
 	It("does not cache non-secret objects", func(ctx SpecContext) {


### PR DESCRIPTION
## Summary

Port of upstream [#508](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/508), [#429](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/429)

Fixes 5 bugs in `ExtendedClient` cache that made caching completely non-functional:

1. **Wrong type assertion in `isObjectCached`**: checked for `*corev1.Secret` instead of `*pgbackrestv1.Archive`, so Archive objects were never recognized as cacheable
2. **GVK comparison in `getCachedObject`**: compared objects via `GetObjectKind().GroupVersionKind()` which returns empty GVK for decoded objects — replaced with `reflect.TypeOf()` comparison
3. **Inverted condition in `removeObject`**: used `!=` instead of `==` for GVK comparison, so cache invalidation never matched the right object — same fix with `reflect.TypeOf()`
4. **Missing TTL initialization**: `cachedEntry.ttl` was never set, defaulting to 0 — every cached entry expired immediately on next access
5. **Incorrect unit comparison in `isExpired()`**: `time.Now().Unix() - fetchUnixTime` returns seconds, but `int64(ttl)` yields nanoseconds — fixed with `time.Since(time.Unix(fetchUnixTime, 0)) > ttl`

Added 5 new unit tests (cache Archive objects, distinguish by type, removeObject matching, removeObject with shared keys, TTL initialization) and updated existing expired test to use real TTL.