### PR TITLE
fix: enable LeaderElectionReleaseOnCancel for rolling updates

### DIFF
--- a/internal/cnpgi/operator/manager.go
+++ b/internal/cnpgi/operator/manager.go
@@ -117,7 +117,7 @@ func Start(ctx context.Context) error {
 		// the manager stops, so would be fine to enable this option. However,
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
-		// LeaderElectionReleaseOnCancel: true,
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
## Summary

Port of upstream [#615](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/615)

Enables `LeaderElectionReleaseOnCancel: true` in the controller manager options.

**Problem**: During rolling updates of the operator deployment, the old pod holds the leader election lease until it expires (default 15s). This means the new pod cannot start reconciliation until the lease times out, causing a gap in controller activity.

**Fix**: Setting `LeaderElectionReleaseOnCancel: true` makes the old leader release the lease immediately on context cancellation (graceful shutdown), so the new pod can acquire leadership instantly.