### PR TITLE
fix: handle empty CurrentPrimary in isStreamingAvailable

### DIFF
--- a/internal/cnpgi/common/wal.go
+++ b/internal/cnpgi/common/wal.go
@@ -431,6 +431,11 @@ func isStreamingAvailable(cluster *cnpgv1.Cluster, podName string) bool {
 		return false
 	}
 
+	// First instance of a new cluster: streaming is not available yet
+	if cluster.Status.CurrentPrimary == "" {
+		return false
+	}
+
 	// Easy case: If this pod is a replica, the streaming is always available
 	if cluster.Status.CurrentPrimary != podName {
 		return true


### PR DESCRIPTION
## Summary

Port of upstream [#604](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/604)

**Problem**: When a brand-new cluster is starting, `cluster.Status.CurrentPrimary` is an empty string until the first pod becomes primary. The `isStreamingAvailable()` function did not handle this case — it fell through to logic that assumed a non-empty primary name, potentially returning incorrect results and causing WAL archiving attempts before the cluster is ready.

**Fix**: Added an early return `false` when `CurrentPrimary == ""`, explicitly handling the bootstrapping phase. Streaming replication cannot be available if no primary has been elected yet.