### PR TITLE
fix: add RBAC clusters/finalizers permission and fix Makefile paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=plugin-pgbackrest crd webhook paths="./api/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=plugin-pgbackrest crd webhook paths="./api/..." paths="./internal/..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -336,12 +336,18 @@ tasks:
         file --path api/v1/zz_generated.deepcopy.go export --path api/v1/zz_generated.deepcopy.go
       - >
         GITHUB_REF= dagger -s call -m github.com/cloudnative-pg/daggerverse/controller-gen@${DAGGER_CONTROLLER_GEN_SHA}
-        controller-gen --source . --args rbac:roleName=plugin-pgbackrest --args crd --args webhook --args paths=./api/...
-        --args output:crd:artifacts:config=config/crd/bases directory --path config/crd/bases export --path config/crd/bases
+        controller-gen --source . --args rbac:roleName=plugin-pgbackrest --args crd --args webhook
+        --args paths=./api/... --args paths=./internal/... --args output:crd:artifacts:config=config/crd/bases
+        directory --path config/
+        filter --include crd/bases/,rbac/
+        export --path config/
     sources:
       - ./api/**/*.go
+      - ./internal/**/*.go
     generates:
       - ./api/v1/zz_generated.deepcopy.go
+      - ./config/rbac/role.yaml
+      - ./config/crd/bases/*.yaml
 
   manifest-main:
     deps:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -49,6 +49,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters/finalizers
+  verbs:
+  - update
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/internal/controller/archive_controller.go
+++ b/internal/controller/archive_controller.go
@@ -42,6 +42,7 @@ type ArchiveReconciler struct {
 // +kubebuilder:rbac:groups=pgbackrest.cnpg.opera.com,resources=archives,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=pgbackrest.cnpg.opera.com,resources=archives/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=pgbackrest.cnpg.opera.com,resources=archives/finalizers,verbs=update
+// +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -980,6 +980,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters/finalizers
+  verbs:
+  - update
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings


### PR DESCRIPTION
## Summary

Port of upstream [#465](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/465).

Also includes the related upstream follow-up for Task-based generation: [#426](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/426).

**Problem 1**: The plugin controller needs to update finalizers on `Cluster` resources (to prevent deletion of clusters that have active archives), but the RBAC role was missing the `clusters/finalizers` update permission. This caused permission-denied errors in the reconciliation loop.

**Problem 2**: The `make manifests` command only scanned `./api/...` for kubebuilder RBAC markers, but the `+kubebuilder:rbac` annotation for clusters/finalizers is in `internal/controller/archive_controller.go`. The generated `role.yaml` was incomplete.

**Problem 3**: CI/release manifests are generated through `task manifest` (Taskfile), so fixing only `Makefile` can still leave generated RBAC/manifests out of sync.

**Fix**: Added `paths="./internal/..."` for controller-gen in `Makefile` and `Taskfile.yml` so RBAC markers under `internal` are included. Added the `+kubebuilder:rbac` marker for `clusters/finalizers` and regenerated RBAC/manifest artifacts.