### PR TITLE
feat: use proper gRPC status codes for WAL errors

### DIFF
--- a/internal/cnpgi/common/errors.go
+++ b/internal/cnpgi/common/errors.go
@@ -1,16 +1,18 @@
 package common
 
-// walNotFoundError is raised when a WAL file has not been found in the object store
-type walNotFoundError struct{}
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
-func newWALNotFoundError() *walNotFoundError { return &walNotFoundError{} }
-
-// ShouldPrintStackTrace tells whether the sidecar log stream should contain the stack trace
-func (e walNotFoundError) ShouldPrintStackTrace() bool {
-	return false
+// newWALNotFoundError creates a gRPC NotFound error for a missing WAL file
+func newWALNotFoundError() error {
+	return status.Error(codes.NotFound, "WAL file not found")
 }
 
-// Error implements the error interface
-func (e walNotFoundError) Error() string {
-	return "WAL file not found"
-}
+// ErrEndOfWALStreamReached is returned when end of WAL is detected in the cloud archive.
+var ErrEndOfWALStreamReached = status.Error(codes.OutOfRange, "end of WAL reached")
+
+// ErrMissingPermissions is returned when the plugin doesn't have the required permissions.
+var ErrMissingPermissions = status.Error(codes.FailedPrecondition,
+	"backup credentials don't yet have access permissions. Will retry reconciliation loop")

--- a/internal/cnpgi/common/wal.go
+++ b/internal/cnpgi/common/wal.go
@@ -109,7 +109,7 @@ func (w WALServiceImplementation) Archive(
 		utils.SanitizedEnviron())
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return nil, errors.New("backup credentials don't yet have access permissions. Will retry reconciliation loop")
+			return nil, ErrMissingPermissions
 		}
 		return nil, err
 	}
@@ -394,7 +394,7 @@ func (w WALServiceImplementation) Status(
 		utils.SanitizedEnviron())
 	if err != nil {
 		if apierrors.IsForbidden(err) {
-			return nil, errors.New("backup credentials don't yet have access permissions. Will retry reconciliation loop")
+			return nil, ErrMissingPermissions
 		}
 		return nil, err
 	}
@@ -483,9 +483,6 @@ func gatherWALFilesToRestore(walName string, parallel int, controlledPromotion b
 
 	return walList, err
 }
-
-// ErrEndOfWALStreamReached is returned when end of WAL is detected in the cloud archive.
-var ErrEndOfWALStreamReached = errors.New("end of WAL reached")
 
 // checkEndOfWALStreamFlag returns ErrEndOfWALStreamReached if the flag is set in the restorer.
 func checkEndOfWALStreamFlag(walRestorer *pgbackrestRestorer.WALRestorer) error {


### PR DESCRIPTION
## Summary

Port of upstream [#549](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/549)

**Problem**: The plugin returned generic gRPC errors (wrapping `errors.New()`) for cases that have well-defined semantics. The CNPG operator could not distinguish a missing WAL (expected during restore) from a real error, and treated S3 permission errors the same as infrastructure failures.

**Fix**: Replaced custom error types with proper gRPC status codes:
- `codes.NotFound` — WAL file not found in object store (replaces custom `walNotFoundError` type)
- `codes.OutOfRange` — end of WAL stream reached during restore (was `errors.New`)
- `codes.FailedPrecondition` — backup credentials don't have required S3 permissions yet (was `errors.New`)

This allows the CNPG operator to handle each case appropriately: retry on FailedPrecondition, stop on OutOfRange, skip on NotFound.