### PR TITLE
feat: replace TYPE_PATCH with TYPE_EVALUATE in lifecycle capabilities

### DIFF
--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -61,7 +61,7 @@ func (impl LifecycleImplementation) GetCapabilities(
 						Type: lifecycle.OperatorOperationType_TYPE_CREATE,
 					},
 					{
-						Type: lifecycle.OperatorOperationType_TYPE_PATCH,
+						Type: lifecycle.OperatorOperationType_TYPE_EVALUATE,
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Port of upstream [#378](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/378), [#222](https://github.com/cloudnative-pg/plugin-barman-cloud/pull/222)

**Problem**: The plugin declared `TYPE_PATCH` capability for pod mutation, which tells the CNPG operator to apply the plugin's response as a direct JSON patch. This is fragile - the plugin must produce correct patches for every possible pod state, and ordering issues between plugins can cause conflicts.

**Fix**: Changed to `TYPE_EVALUATE`, which lets the operator evaluate the plugin's desired state before creating/updating pods and trigger rollout when needed. This is the recommended approach in cnpg-i v0.3.0 and reduces the risk of conflicts when multiple plugins mutate the same pod.

**Compatibility**: Requires a CNPG operator version that supports the `EVALUATE` lifecycle verb. This repository already targets CloudNativePG v1.27.x, so the requirement is already satisfied.