### PR TITLE
fix: update dagger uncommitted module to fix setuptools error

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,7 +61,7 @@ tasks:
       - manifest-main
     env:
       # renovate: datasource=git-refs depName=uncommitted lookupName=https://github.com/cloudnative-pg/daggerverse currentValue=main
-      DAGGER_UNCOMMITTED_SHA: 9151fdb403298e305889668706b6cd69bb287e88
+      DAGGER_UNCOMMITTED_SHA: 9db5f17ca5ef69cc1ab20336eaf337fb11246728
     cmds:
       - GITHUB_REF= dagger -s call -m github.com/cloudnative-pg/daggerverse/uncommitted@${DAGGER_UNCOMMITTED_SHA} check-uncommitted --source . stdout
     sources:


### PR DESCRIPTION
## Summary

Updates the `uncommitted` dagger module SHA from `9151fdb` to `9db5f17` to pick up the fix from [cloudnative-pg/daggerverse#120](https://github.com/cloudnative-pg/daggerverse/pull/120).

**Problem**: CI fails on all PRs with `ModuleNotFoundError: No module named 'pkg_resources'` because the Python image used by the `uncommitted` module no longer includes `setuptools` by default.

**Fix**: Bump `DAGGER_UNCOMMITTED_SHA` to the version that pins `setuptools`.