### PR TITLE
fix(ci): make golangci-lint output visible and fix issues

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,10 +24,11 @@ tasks:
       GOLANG_IMAGE_VERSION: 1.25.5
     cmds:
       - >
-        GITHUB_REF= dagger -sc "github.com/sagikazarmark/daggerverse/golangci-lint@${DAGGER_GOLANGCI_LINT_SHA}
+        output=$(GITHUB_REF= dagger -sc "github.com/sagikazarmark/daggerverse/golangci-lint@${DAGGER_GOLANGCI_LINT_SHA}
         --go-version ${GOLANG_IMAGE_VERSION} |
-        run . --config .golangci.yml |
-        stdout"
+        run . --config .golangci.yml --raw-args --issues-exit-code=0 |
+        stdout");
+        if [ "$output" != "0 issues." ]; then echo "output=$output"; exit 1; fi
     sources:
       - ./**/*.go
 

--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -40,6 +40,12 @@ import (
 	"github.com/operasoftware/cnpg-plugin-pgbackrest/internal/cnpgi/operator/config"
 )
 
+const (
+	kindPod             = "Pod"
+	kindJob             = "Job"
+	jobRoleFullRecovery = "full-recovery"
+)
+
 // LifecycleImplementation is the implementation of the lifecycle handler
 type LifecycleImplementation struct {
 	lifecycle.UnimplementedOperatorLifecycleServer
@@ -55,7 +61,7 @@ func (impl LifecycleImplementation) GetCapabilities(
 		LifecycleCapabilities: []*lifecycle.OperatorLifecycleCapabilities{
 			{
 				Group: "",
-				Kind:  "Pod",
+				Kind:  kindPod,
 				OperationTypes: []*lifecycle.OperatorOperationType{
 					{
 						Type: lifecycle.OperatorOperationType_TYPE_CREATE,
@@ -67,7 +73,7 @@ func (impl LifecycleImplementation) GetCapabilities(
 			},
 			{
 				Group: batchv1.GroupName,
-				Kind:  "Job",
+				Kind:  kindJob,
 				OperationTypes: []*lifecycle.OperatorOperationType{
 					{
 						Type: lifecycle.OperatorOperationType_TYPE_CREATE,
@@ -112,10 +118,10 @@ func (impl LifecycleImplementation) LifecycleHook(
 	}
 
 	switch kind {
-	case "Pod":
+	case kindPod:
 		contextLogger.Info("Reconciling pod")
 		return impl.reconcilePod(ctx, &cluster, request, pluginConfiguration)
-	case "Job":
+	case kindJob:
 		contextLogger.Info("Reconciling job")
 		return impl.reconcileJob(ctx, &cluster, request, pluginConfiguration)
 	default:
@@ -270,7 +276,7 @@ func reconcileJob(
 		WithValues("jobName", job.Name)
 	contextLogger.Debug("starting job reconciliation")
 
-	if job.Spec.Template.Labels[utils.JobRoleLabelName] != "full-recovery" {
+	if job.Spec.Template.Labels[utils.JobRoleLabelName] != jobRoleFullRecovery {
 		contextLogger.Debug("job is not a recovery job, skipping")
 		return nil, nil
 	}
@@ -280,7 +286,7 @@ func reconcileJob(
 	if err := reconcilePodSpec(
 		cluster,
 		&mutatedJob.Spec.Template.Spec,
-		"full-recovery",
+		jobRoleFullRecovery,
 		corev1.Container{
 			Args: []string{"restore"},
 		},

--- a/internal/pgbackrest/archiver/command.go
+++ b/internal/pgbackrest/archiver/command.go
@@ -66,6 +66,8 @@ func (archiver *WALArchiver) GatherWALFilesToArchive(
 	// a relative path might be used in some cases.
 	walList[0] = filepath.Join(pgWalDirectory, filepath.Base(requestedWALFile))
 
+	// G703: archiveStatusPath is derived from the PGDATA env variable and a fixed suffix, not user input
+	//nolint:gosec
 	err := filepath.WalkDir(archiveStatusPath, func(path string, d os.DirEntry, err error) error {
 		// If err is set, it means the current path is a directory and the readdir raised an error
 		// The only available option here is to skip the path and log the error.


### PR DESCRIPTION
After rewrite of the dagger call convention, linter no longer shows any output on failure, making debugging much harder.
Output for success is just "issues: 0" so we can match on that (although it's not ideal).

One false-positive and a few constant extraction recommendations appeared in the meantime.