### PR TITLE
fix(restorer): return ErrWALNotFound on archive-get not-found exit

### DIFF
--- a/internal/pgbackrest/restorer/wal.go
+++ b/internal/pgbackrest/restorer/wal.go
@@ -35,6 +35,10 @@ import (
 
 const (
 	endOfWALStreamFlagFilename = "end-of-wal-stream"
+
+	// walNotFoundExitCode is the pgbackrest archive-get exit code returned when
+	// the requested WAL is not present in a valid repository.
+	walNotFoundExitCode = 1
 )
 
 // ErrWALNotFound is returned when the WAL is not found in the cloud archive
@@ -263,15 +267,23 @@ func (restorer *WALRestorer) Restore(
 		"command", "pgbackrest",
 		"options", options,
 	)
+	return walRestoreError(walName, err)
+}
+
+// walRestoreError maps a pgbackrest archive-get failure to a typed error,
+// returning ErrWALNotFound when the requested WAL is missing from the archive.
+func walRestoreError(walName string, err error) error {
 	var exitError *exec.ExitError
 	if !errors.As(err, &exitError) {
 		return fmt.Errorf("unexpected failure retrieving %q with %s: %w",
 			walName, "pgbackrest archive-get", err)
 	}
 
-	exitCode := exitError.ExitCode()
+	if exitError.ExitCode() == walNotFoundExitCode {
+		return ErrWALNotFound
+	}
 
 	return fmt.Errorf("encountered an error: '%d' while executing %s",
-		exitCode,
+		exitError.ExitCode(),
 		"pgbackrest archive-get")
 }

--- a/internal/pgbackrest/restorer/wal_test.go
+++ b/internal/pgbackrest/restorer/wal_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025, Opera Norway AS
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restorer
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("walRestoreError", func() {
+	const walName = "000000010000000000000001"
+
+	exitError := func(code int) error {
+		return exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	}
+
+	It("returns ErrWALNotFound when archive-get reports the WAL is missing", func() {
+		Expect(walRestoreError(walName, exitError(walNotFoundExitCode))).To(MatchError(ErrWALNotFound))
+	})
+
+	It("returns a generic error for other non-zero exit codes", func() {
+		err := walRestoreError(walName, exitError(103))
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(MatchError(ErrWALNotFound))
+		Expect(err.Error()).To(ContainSubstring("103"))
+	})
+
+	It("wraps failures that are not exit errors", func() {
+		sentinel := errors.New("spawn failure")
+
+		err := walRestoreError(walName, sentinel)
+
+		Expect(err).To(MatchError(sentinel))
+		Expect(err).NotTo(MatchError(ErrWALNotFound))
+	})
+})


### PR DESCRIPTION
## What

`WALRestorer.Restore` now returns the `ErrWALNotFound` sentinel when `pgbackrest
archive-get` reports the WAL segment as missing (exit code `1`), instead of collapsing
every non-zero exit code into a single generic error.

https://github.com/operasoftware/cnpg-plugin-pgbackrest/issues/105

## Why

`ErrWALNotFound` is defined in `internal/pgbackrest/restorer/wal.go` and checked in three
places to tell the normal end-of-WAL case apart from a real failure:

- `internal/pgbackrest/restorer/wal.go` — Info vs Warning log level for the requested WAL
- `internal/cnpgi/common/wal.go` — return the `codes.NotFound` gRPC status
  (`newWALNotFoundError`) instead of a raw error
- `internal/cnpgi/common/wal.go` — `isEndOfWALStream()` prefetch/end-of-stream detection

But nothing ever produced it: the only place that runs `archive-get` returned a generic
`fmt.Errorf` for **any** non-zero exit code, so `errors.Is(err, ErrWALNotFound)` was always
`false` and all three checks were dead code.

This does not change whether recovery works — PostgreSQL treats any non-zero `restore_command`
as "WAL unavailable" and switches to streaming either way. The fix just stops the plugin from
misreporting the normal end-of-WAL:

- **Logs (always).** A replica tries the archive for each new WAL before it has been archived;
  this normal miss was logged as `Warning` ("Failed restoring WAL file") and now logs as
  `Info` ("WAL file not found"). Healthy replicas stop emitting warnings that look like
  failures.
- **Fewer object-store lookups (only when `wal.maxParallel > 1`).** With parallel prefetch the
  plugin can now set its `end-of-wal-stream` flag and stop re-requesting segments it already
  knows are missing. No effect at the default `maxParallel=1`.
- **Diagnostics.** exit `103` (`RepoInvalidError` — stanza/repo not initialized) is no longer
  indistinguishable from a normal "WAL not there yet".

`pgbackrest archive-get` returns exit code `1` specifically when a segment is not present
in an otherwise-valid repository (its default `int result = 1`; pgBackRest exception codes
start at `25`, so `1` is unambiguously "not found"). Mapping that code restores the
intended behaviour and keeps every other non-zero code (including `103`) as a real error.

## Behaviour

| `archive-get` exit | Before | After |
|---|---|---|
| `1` (WAL not found) | generic error | `ErrWALNotFound` |
| `103` (repo invalid) | generic error | generic error (unchanged) |
| other non-zero | generic error | generic error (unchanged) |
| non-exit failure | wrapped error | wrapped error (unchanged) |

Recovery correctness is unchanged — PostgreSQL already treats any non-zero
`restore_command` as "WAL unavailable" and switches to streaming; this only makes the
plugin signal and log the two conditions correctly.

## Changes

- `internal/pgbackrest/restorer/wal.go`: extract exit-code handling into `walRestoreError`
  and map the not-found exit code to `ErrWALNotFound`.
- `internal/pgbackrest/restorer/wal_test.go`: unit tests for `walRestoreError` covering the
  not-found code, other non-zero codes, and non-exit failures.

## Testing

```
go build ./...                                     # ok
gofmt -l internal/pgbackrest/restorer/...          # clean
go vet ./internal/pgbackrest/restorer/...          # clean
golangci-lint run ./internal/pgbackrest/restorer/... # 0 issues (v2.1.5)
go test ./internal/pgbackrest/restorer/...         # ok — 6 specs, 3 new
```

## Checklist

- [x] Conventional commit with `Signed-off-by` (DCO)
- [x] Unit tests added
- [x] `gofmt` / `go vet` / `golangci-lint` (v2.1.5) clean
- [x] No behaviour change to recovery correctness; scope limited to error typing
