### PR TITLE
chore(renovate): improve file regeneration and sync more tools via renovate

### DIFF
--- a/.github/workflows/renovate-regenerate.yml
+++ b/.github/workflows/renovate-regenerate.yml
@@ -20,6 +20,13 @@ on:
     types: [opened, synchronize]
     paths:
       - Taskfile.yml
+      # Our CRD types embed types from CNPG's own Go modules (e.g. cloudnative-pg/api).
+      # A version bump there can change generated output even without touching
+      # Taskfile.yml: controller-gen embeds referenced types' full structure *and* Go
+      # doc comments into the CRD schema, so even a docs-only change upstream can
+      # produce a real diff in config/crd/bases and manifest.yaml.
+      - go.mod
+      - go.sum
 
 permissions:
   contents: write

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,11 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 KUSTOMIZE_VERSION ?= v5.4.3
 # renovate: datasource=github-tags depName=kubernetes-sigs/controller-tools versioning=semver
 CONTROLLER_TOOLS_VERSION ?= v0.21.0
-ENVTEST_VERSION ?= release-0.19
+# Pinned to an exact tag (not the upstream release-0.19 branch convention) so renovate can
+# track it. Kept in sync with go.mod's sigs.k8s.io/controller-runtime require and
+# Taskfile.yml's SETUP_ENVTEST_VERSION: same depName/datasource, combined into one PR.
+# renovate: datasource=go depName=sigs.k8s.io/controller-runtime versioning=semver
+ENVTEST_VERSION ?= v0.19.3
 GOLANGCI_LINT_VERSION ?= v2.1.5
 
 .PHONY: kustomize

--- a/Makefile
+++ b/Makefile
@@ -159,15 +159,17 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
+# renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5 versioning=semver
 KUSTOMIZE_VERSION ?= v5.4.3
 # renovate: datasource=github-tags depName=kubernetes-sigs/controller-tools versioning=semver
 CONTROLLER_TOOLS_VERSION ?= v0.21.0
-# Pinned to an exact tag (not the upstream release-0.19 branch convention) so renovate can
-# track it. Kept in sync with go.mod's sigs.k8s.io/controller-runtime require and
-# Taskfile.yml's SETUP_ENVTEST_VERSION: same depName/datasource, combined into one PR.
+# Kept in sync with go.mod's sigs.k8s.io/controller-runtime require and
+# Taskfile.yml's SETUP_ENVTEST_VERSION: same depName/datasource by renovate.
 # renovate: datasource=go depName=sigs.k8s.io/controller-runtime versioning=semver
 ENVTEST_VERSION ?= v0.19.3
-GOLANGCI_LINT_VERSION ?= v2.1.5
+# Kept in sync with Taskfile by renovate.
+# renovate: datasource=github-tags depName=golangci/golangci-lint versioning=semver
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,10 +22,15 @@ tasks:
       DAGGER_GOLANGCI_LINT_SHA: ff27cd50f6b4eed2e3753c520632cd6099e1ce52
       # renovate: datasource=docker depName=golang versioning=semver
       GOLANG_IMAGE_VERSION: 1.26.4
+      # Without an explicit version, this module defaults to the "latest" golangci-lint
+      # image tag, which isn't reproducible across CI runs. Kept in sync with the
+      # Makefile's GOLANGCI_LINT_VERSION: same depName/datasource, combined into one PR.
+      # renovate: datasource=github-tags depName=golangci/golangci-lint versioning=semver
+      GOLANGCI_LINT_VERSION: v2.12.2
     cmds:
       - >
         output=$(GITHUB_REF= dagger -sc "github.com/sagikazarmark/daggerverse/golangci-lint@${DAGGER_GOLANGCI_LINT_SHA}
-        --go-version ${GOLANG_IMAGE_VERSION} |
+        --go-version ${GOLANG_IMAGE_VERSION} --version ${GOLANGCI_LINT_VERSION} |
         run . --config .golangci.yml --raw-args --issues-exit-code=0 |
         stdout");
         if [ "$output" != "0 issues." ]; then echo "output=$output"; exit 1; fi
@@ -417,15 +422,21 @@ tasks:
     env:
       # renovate: datasource=github-digest depName=kustomize lookupName=sagikazarmark/daggerverse currentValue=main
       DAGGER_KUSTOMIZE_SHA: ff27cd50f6b4eed2e3753c520632cd6099e1ce52
+      # Kept in sync with the Makefile's KUSTOMIZE_VERSION: same depName/datasource,
+      # combined into one PR.
+      # renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5 versioning=semver
+      KUSTOMIZE_VERSION: v5.4.3
     cmds:
       - >
         dagger -s call -m https://github.com/sagikazarmark/daggerverse/kustomize@${DAGGER_KUSTOMIZE_SHA}
+        --version ${KUSTOMIZE_VERSION}
         edit --source . --dir kubernetes
         set image --image plugin-pgbackrest={{.PLUGIN_IMAGE_NAME}}:{{.IMAGE_VERSION}}
         set secret --secret plugin-pgbackrest --from-literal SIDECAR_IMAGE={{.SIDECAR_IMAGE_NAME}}:{{.IMAGE_VERSION}}
         directory directory --path kubernetes export --path manifest-build
       - >
         dagger -s call -m github.com/sagikazarmark/daggerverse/kustomize@${DAGGER_KUSTOMIZE_SHA}
+        --version ${KUSTOMIZE_VERSION}
         build --source . --dir manifest-build export --path manifest.yaml
     sources:
       - ./config/**/*.yaml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,7 +75,10 @@ tasks:
       GOLANG_IMAGE_VERSION: 1.26.4
       # renovate: datasource=github-digest depName=kubernetes packageName=kubernetes/kubernetes versioning=semver
       K8S_VERSION: 1.31.0
-      # renovate: datasource=github-digest depName=controller-runtime packageName=kubernetes-sigs/controller-runtime versioning=semver
+      # Kept in sync with go.mod's sigs.k8s.io/controller-runtime require: same
+      # depName/datasource as the native gomod dependency, so renovate combines both
+      # bumps into a single branch/PR instead of opening two.
+      # renovate: datasource=go depName=sigs.k8s.io/controller-runtime versioning=semver
       SETUP_ENVTEST_VERSION: 0.19.3
     cmds:
       - >


### PR DESCRIPTION
* Regenerate files on go dependency changes - required as we embed types from dependencies in CRDs,
* sync golangci-lint and kustomize between taskfile and makefile + freeze versions in taskfile,
* sync testenv/controller-runtime versions across makefile, taskfile and go dependencies.