### PR TITLE
chore(ci): renovate all Kubernetes distributions together and skip broken one

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -276,7 +276,12 @@ tasks:
     vars:
       # renovate: datasource=docker depName=golang versioning=semver
       GOLANG_IMAGE_VERSION: 1.26.5
-      # renovate: datasource=docker depName=k3s  versioning=semver
+      # rancher/k3s tags look like v1.33.1-k3s1 (upstream k8s version + k3s build number).
+      # Without extractVersion, semver treats that "-k3s1" as a prerelease identifier,
+      # so every real tag compares as *older* than the bare version stored below and
+      # renovate never proposes anything. extractVersion strips the v prefix and -k3sN
+      # suffix so comparisons match this file's plain-number convention.
+      # renovate: datasource=docker depName=rancher/k3s versioning=semver extractVersion=^v(?<version>\d+\.\d+\.\d+)-k3s\d+$
       K3S_IMAGE_VERSION: 1.33.1
     env:
       _EXPERIMENTAL_DAGGER_RUNNER_HOST: docker-container://{{ .DAGGER_ENGINE_CONTAINER_NAME }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -140,6 +140,29 @@
       minimumReleaseAge: '3 days',
     },
     {
+      // Different projects/sources (vanilla k8s, kind's node image, k3s) tracking
+      // roughly the same Kubernetes version - intentionally not merged into a single
+      // dependency (they have independent release cadences), just batched into one PR
+      // when their updates happen to overlap so they're reviewed together.
+      matchPackageNames: [
+        'kubernetes/kubernetes',
+        'kindest/node',
+        'rancher/k3s',
+      ],
+      groupName: 'kubernetes versions (k8s, kind, k3s)',
+      minimumReleaseAge: '3 days',
+    },
+    {
+      // envtest has no published binaries for 1.36.3 yet, breaking go-test. Scoped to
+      // kubernetes/kubernetes only - kindest/node and rancher/k3s don't use envtest and
+      // aren't affected. Remove once envtest publishes binaries for this version.
+      // allowedVersions can't be combined with matchUpdateTypes in the same rule.
+      matchPackageNames: [
+        'kubernetes/kubernetes',
+      ],
+      allowedVersions: '!/^v?1\\.36\\.3$/',
+    },
+    {
       matchUpdateTypes: [
         'minor',
         'patch',


### PR DESCRIPTION
There are 3 different Kubernetes distributions used across the project: K3s, Kind and the one in envtest.

All were already handled (with k3s having a broken reference to the image and not being executed) but in separate PRs. Now they should be grouped when possible.

In addition, envtest is missing binaries for 1.36.3 so let's skip this release. It seems they are missing releases quite often, like every other one.